### PR TITLE
Changed timeout to 30min (1800s)

### DIFF
--- a/single_school_get_MIT_activity_data/single_school_get_MIT_activity_data.py
+++ b/single_school_get_MIT_activity_data/single_school_get_MIT_activity_data.py
@@ -164,9 +164,7 @@ def export_qbank_data():
 
         )
 
-        p = pexpect.spawn(command,
-
-                          timeout=60)
+        p = pexpect.spawn(command, timeout=1800)
 
         p.expect('done dumping')
 


### PR DESCRIPTION
When _pexpect.spawn()_ was executing '_mongo dump_' command to get data from school DB into tar file for syncthing purpose, only partial data was being dumped (how much ever could be dumped in first 60 sec). This is due to _'[timeout](https://pexpect.readthedocs.io/en/stable/api/pexpect.html#spawn-class)'_ flag causing (_mongo dump_)process to stop after 60sec irrespecctive of how much data is dumped from DB.